### PR TITLE
Add ObjectSid to the omniauth strategies params

### DIFF
--- a/lib/omniauth/strategies/ldap.rb
+++ b/lib/omniauth/strategies/ldap.rb
@@ -17,7 +17,8 @@ module OmniAuth
         'uid' => 'dn',
         'url' => ['wwwhomepage'],
         'image' => 'jpegPhoto',
-        'description' => 'description'
+        'description' => 'description',
+        'object_sid' => 'ObjectSid'
       }
       option :title, "LDAP Authentication" #default title for authentication form
       option :port, 389


### PR DESCRIPTION
# Wat
ObjectSid uniquely identifies a user on LDAP. We need it to be able to identify the user on another systems which also use the same id.

# Gif

![](http://i.giphy.com/gitY3JY8QFGEM.gif)