### PR TITLE
Update rubyntlm dependency version

### DIFF
--- a/omniauth-ldap.gemspec
+++ b/omniauth-ldap.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency     'omniauth', '~> 1.1.1'
   gem.add_runtime_dependency     'net-ldap', '~> 0.4.0'
   gem.add_runtime_dependency     'pyu-ruby-sasl', '~> 0.0.3.1'
-  gem.add_runtime_dependency     'rubyntlm', '~> 0.1.1'
+  gem.add_runtime_dependency     'rubyntlm', '~> 0.3'
   gem.add_development_dependency 'rspec', '~> 2.7'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'rack-test'


### PR DESCRIPTION
I need this dependency updated in order to install other gems.

This change already exists in the master branch of the original repo: https://github.com/intridea/omniauth-ldap/commit/259461052a3454529115ce41ece8f81de86f2cff